### PR TITLE
Add field number error correction warning

### DIFF
--- a/file-format-verification/__tests__/containers/App.js
+++ b/file-format-verification/__tests__/containers/App.js
@@ -19,7 +19,7 @@ describe('AppContainer', () => {
 
   it('renders the component', () => {
     expect(containerNode).toBeDefined()
-    expect(containerNode.firstChild.textContent).toEqual('Skip to main content')
+    expect(containerNode.firstChild.textContent).toEqual('This website is a work in progress')
     expect(console.error).not.toBeCalled()
   })
 })

--- a/file-format-verification/src/js/components/ParseErrors.jsx
+++ b/file-format-verification/src/js/components/ParseErrors.jsx
@@ -52,8 +52,9 @@ const renderTSErrors = (transmittalSheetErrors) => {
 }
 
 const renderParseResults = (count) => {
-  const successCopy = 'Congratulations, your file has no formatting errors.'
+  const successCopy = 'Congratulations! Your file has no formatting errors.'
   const failCopy = 'Your file failed to parse. Please fix the following errors and try again.'
+  const numberOfFieldsWarning = <p>Rows without the correct number of fields will need to be fixed and reuploaded before other errors can be checked.</p>
   const errorText = count === 1 ? 'Error' : 'Errors'
   const noErrors = count === 0
 
@@ -63,6 +64,7 @@ const renderParseResults = (count) => {
         {noErrors ? 'No' : count} Formatting {errorText}
       </h2>
       <p className="usa-font-lead">{noErrors ? successCopy : failCopy}</p>
+      {noErrors ? null : numberOfFieldsWarning }
     </div>
   )
 }


### PR DESCRIPTION
Helps clear up that rows cannot be checked for errors (other than number of rows) if a number-of-rows error exists.

Closes #11 