### PR TITLE
Duplicative image

### DIFF
--- a/check-digit/src/js/LoadingIcon.jsx
+++ b/check-digit/src/js/LoadingIcon.jsx
@@ -3,7 +3,7 @@ import React from 'react'
 const LoadingIcon = () => {
   return (
     <div className="LoadingIconWrapper">
-      <img src="./img/LoadingIcon.png" className="LoadingIcon" alt="Loading" />
+      <img src="/img/LoadingIcon.png" className="LoadingIcon" alt="Loading" />
     </div>
   )
 }

--- a/check-digit/src/sass/_LoadingIcon.scss
+++ b/check-digit/src/sass/_LoadingIcon.scss
@@ -7,7 +7,6 @@
 
 .LoadingIcon {
   animation: loading-spin 2s infinite linear;
-  background-image: url("/img/LoadingIcon.png");
   width: 30px;
 }
 

--- a/file-format-verification/src/js/notes.txt
+++ b/file-format-verification/src/js/notes.txt
@@ -1,6 +1,0 @@
-pagination key in reducer
-currentPage, max pages, etc
-  - set on parse complete
-  - dispatch action to update page
-  - might need actions for fade stuff (yuck)
-  - pagination fade is its own thing?

--- a/file-format-verification/src/sass/components/_LoadingIcon.scss
+++ b/file-format-verification/src/sass/components/_LoadingIcon.scss
@@ -1,12 +1,11 @@
 .LoadingIconWrapper {
   -webkit-transform: rotateX(180deg);
   width: 3em;
-  margin: 0 auto;
+  margin: 0;
   transform: rotateX(180deg);
 }
 
 .LoadingIcon {
-  background-image:url('/img/LoadingIcon.png');
   width: 3em;
   animation: loading-spin 2s infinite linear;
 }

--- a/rate-spread/src/js/LoadingIcon.jsx
+++ b/rate-spread/src/js/LoadingIcon.jsx
@@ -3,7 +3,7 @@ import React from 'react'
 const LoadingIcon = () => {
   return (
     <div className="LoadingIconWrapper">
-      <img src="./img/LoadingIcon.png" className="LoadingIcon" alt="Loading" />
+      <img src="/img/LoadingIcon.png" className="LoadingIcon" alt="Loading" />
     </div>
   )
 }

--- a/rate-spread/src/sass/_LoadingIcon.scss
+++ b/rate-spread/src/sass/_LoadingIcon.scss
@@ -7,7 +7,6 @@
 
 .LoadingIcon {
   animation: loading-spin 2s infinite linear;
-  background-image: url("/img/LoadingIcon.png");
 }
 
 @keyframes loading-spin {


### PR DESCRIPTION
Similar to https://github.com/cfpb/hmda-platform-ui/pull/970, removes a duplicative background-image rule to sharpen and smooth the loading icon. Also, adjusts the js to use the loading icon png that is common to all tools, rather than per project images.