### PR TITLE
Fix empty last page of ffvt

### DIFF
--- a/src/file-format-verification/reducers/index.js
+++ b/src/file-format-verification/reducers/index.js
@@ -128,7 +128,7 @@ export const pagination = (state = defaultPagination, action) => {
     case END_PARSE:
       return {
         page: 1,
-        total: ((action.larErrors.length / ERRORS_PER_PAGE) >> 0) + 1,
+        total: Math.ceil(action.larErrors.length / ERRORS_PER_PAGE) || 1,
         fade: 0
       }
     case PAGINATION_FADE_IN:


### PR DESCRIPTION
Changes the logic of page counts to prevent an empty last page when total errors is divisible by `ERRORS_PER_PAGE`