### PR TITLE
update all api calls to now use a relative path

### DIFF
--- a/src/check-digit/CSVUpload.jsx
+++ b/src/check-digit/CSVUpload.jsx
@@ -91,7 +91,7 @@ class CSVUpload extends PureComponent {
           />
           <input
             onChange={this.makeSelectHandler(
-              'https://ffiec-api.cfpb.gov/public/uli/checkDigit/csv',
+              '/v2/public/uli/checkDigit/csv',
               'generated'
             )}
             type="file"
@@ -106,7 +106,7 @@ class CSVUpload extends PureComponent {
           <p>
             <input
               onChange={this.makeSelectHandler(
-                'https://ffiec-api.cfpb.gov/public/uli/validate/csv',
+                '/v2/public/uli/validate/csv',
                 'validated'
               )}
               type="file"

--- a/src/check-digit/index.jsx
+++ b/src/check-digit/index.jsx
@@ -98,7 +98,7 @@ export default class App extends Component {
       }
     }
 
-    const API_URL = 'https://ffiec-api.cfpb.gov/public/uli/'
+    const API_URL = '/v2/public/uli/'
 
     if (this.state.isSubmitted) {
       isomorphicFetch(API_URL + endpoint, {

--- a/src/file-format-verification/actions/index.js
+++ b/src/file-format-verification/actions/index.js
@@ -83,7 +83,7 @@ export function triggerParse(file, filingPeriod) {
       var formData = new FormData()
       formData.append('file', file)
 
-      isomorphicFetch('https://ffiec-api.cfpb.gov/v2/public/hmda/parse', {
+      isomorphicFetch('/v2/public/hmda/parse', {
         method: 'POST',
         body: formData
       })

--- a/src/rate-spread/CSVUpload.jsx
+++ b/src/rate-spread/CSVUpload.jsx
@@ -64,7 +64,7 @@ class CSVUpload extends Component {
     event.target.value = null
 
     this.onCSVFetch()
-    const CSV_URL = 'https://ffiec-api.cfpb.gov/public/rateSpread/csv'
+    const CSV_URL = '/v2/public/rateSpread/csv'
     runFetch(CSV_URL, this.prepareCSVBody(file), true).then(res => {
       this.onCSVCalculated(res, file)
     })

--- a/src/rate-spread/Form.jsx
+++ b/src/rate-spread/Form.jsx
@@ -174,7 +174,7 @@ class Form extends Component {
       if (errs.rateSetDate || errs.APR || errs.loanTerm) return
 
       this.onFetch()
-      const API_URL = 'https://ffiec-api.cfpb.gov/public/rateSpread'
+      const API_URL = '/v2/public/rateSpread'
       runFetch(API_URL, this.prepareBodyFromState()).then(res => {
         this.onCalculated(res)
       })


### PR DESCRIPTION
On the v2 setup, we'll be able to use relative paths for the API calls.